### PR TITLE
Docker-Compose --exit-code-from fix

### DIFF
--- a/src/Cake.Docker/Compose/Up/DockerComposeUpSettings.cs
+++ b/src/Cake.Docker/Compose/Up/DockerComposeUpSettings.cs
@@ -57,7 +57,8 @@
         /// Return the exit code of the selected service container.
         ///   Implies --abort-on-container-exit.
         /// </summary>
-        public bool ExitCodeFrom { get; set; }
+        [AutoProperty(Format = "--exit-code-from {1}")]
+        public string ExitCodeFrom { get; set; }
         /// <summary>
         /// SERVICE=NUM        Scale SERVICE to NUM instances. Overrides the `scale`
         ///   setting in the Compose file if present.


### PR DESCRIPTION
Right now `--exit-code-from` does not work properly. See `docker-compose up` documentation https://docs.docker.com/compose/reference/up/

```
--exit-code-from SERVICE   Return the exit code of the selected service
                               container. Implies --abort-on-container-exit.
```

This change will fix(I hope) this issue.